### PR TITLE
Update go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/creativenucleus/bytejammer
 
-go 1.21.1
+go 1.21
 
 require (
 	github.com/google/uuid v1.3.1


### PR DESCRIPTION
Make 'go build' work under macos (or get error on with version 1.21.1)

PS i am a total noob with go, if if this change is misplaced ignore this. 

